### PR TITLE
Improve comments in demo on registry examples

### DIFF
--- a/demo/demo1/extensions/extension.1.js
+++ b/demo/demo1/extensions/extension.1.js
@@ -144,6 +144,14 @@
         extensionRegistry.register('thing');
         extensionRegistry.register('thing', []);
 
+        // the registry system is tolerant of errors to avoid one extension
+        // causing other extensions to fail.  registering an error or returning
+        // an error will do nothing.
+        extensionRegistry.register('thing', new Error('Oh no, it broke!'));
+        extensionRegistry.register('thing', function() {
+          return new Error('Oh no, bad things!!!!');
+        });
+
         // deregistering will trigger a UI update & re-render
         $timeout(function() {
           registries[0].deregister();


### PR DESCRIPTION
Show that registering an error or returning an error will not break other registered extensions.
