### PR TITLE
[WIP] Add convenience wrapper to .add() when registering data

### DIFF
--- a/src/services/extension-registry-provider.js
+++ b/src/services/extension-registry-provider.js
@@ -36,6 +36,13 @@
               if(builderFn && isFunction(builderFn)) {
                 registry[name][key] = builderFn;
                 notify();
+              } else {
+                // supports convenience of add('name', object)
+                // if builderFn isn't a fn, wrap the object 
+                registry[name][key] = function() {
+                  return builderFn;
+                };
+                notify();
               }
               // handle.remove() will deregister, otherwise pass to:
               // extensionRegistry.remove(handle)


### PR DESCRIPTION
Noticed this as I was working on tests.  It is desirable to support both syntaxes:

```javascript 
// preferred method can receive context args
extensionRegistry.add('foo', function(args) {
  return $q.when([{ bar: 'baz' }]);
});

// but a simple registry is also handy 
extensionRegistry.add('foo', { bar: 'baz' });
```
TODO: 
- [ ] tests